### PR TITLE
Add ofrep flag evaluation tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,57 @@ All logs are written to stderr. The MCP protocol messages use stdout.
 
 ### `install_openfeature_sdk`
 
+### `ofrep_flag_eval`
+
+Evaluate flags using the OpenFeature Remote Evaluation Protocol (OFREP) [specification](`https://github.com/open-feature/protocol`). If `flag_key` is provided, performs a single-flag evaluation; otherwise, performs a bulk evaluation per the [OpenAPI definition](`https://raw.githubusercontent.com/open-feature/protocol/refs/heads/main/service/openapi.yaml`).
+
+Inputs:
+
+- `baseUrl` (string, optional): Base URL of your OFREP service (e.g. `https://flags.example.com`). If omitted, uses `OFREP_BASE_URL` env var.
+- `flag_key` (string, optional): When set, uses single-flag endpoint; otherwise uses bulk endpoint.
+- `targetingKey` (string, optional): Added to the evaluation context as `context.targetingKey`.
+- `context` (object, optional): Additional evaluation context properties.
+- `apiKey` (string, optional): Sends `x-api-key` header. If omitted, uses `OFREP_API_KEY` env var.
+- `bearerToken` (string, optional): Sends `Authorization: Bearer ...`. If omitted, uses `OFREP_BEARER_TOKEN` env var.
+- `headers` (object, optional): Extra headers to include.
+- `ifNoneMatch` (string, optional): ETag for bulk evaluation cache validation. Returns 304 if not modified.
+- `timeoutMs` (number, optional): Request timeout in milliseconds.
+
+Output:
+
+- JSON string with `status`, optional `etag`, and `data` (parsed response). If bulk eval returns 304, `notModified: true` is set.
+
+Examples:
+
+Bulk evaluation with env-configured auth:
+
+```json
+{
+  "baseUrl": "https://flags.example.com",
+  "context": { "plan": "pro" },
+  "ifNoneMatch": "\"etag-from-previous-call\""
+}
+```
+
+Single flag evaluation with explicit bearer token:
+
+```json
+{
+  "baseUrl": "https://flags.example.com",
+  "flag_key": "my-flag",
+  "targetingKey": "user-123",
+  "bearerToken": "<token>"
+}
+```
+
+Authentication configuration options:
+
+- Environment variables: set `OFREP_BASE_URL`, `OFREP_API_KEY`, and/or `OFREP_BEARER_TOKEN` before launching the server.
+- MCP client config (when supported): some clients allow passing env into the MCP server command. For example, you can wrap the `npx` call in a shell script that exports env vars.
+- Local shell profile: export the variables in your shell (e.g., `.bashrc`, `.zshrc`) so they apply to the `npx @openfeature/mcp` invocation.
+
+References: [OFREP repository](`https://github.com/open-feature/protocol`), [OFREP OpenAPI](`https://raw.githubusercontent.com/open-feature/protocol/refs/heads/main/service/openapi.yaml`).
+
 Fetches and returns OpenFeature SDK install prompt Markdown for a given guide from the bundled prompts.
 
 **Parameters:**

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,6 +4,7 @@ import type { ZodRawShape } from "zod";
 import type { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
 import { workerVersion } from "./version.js";
 import { registerInstallTools } from "./tools/installTools.js";
+import { registerOfrepTools } from "./tools/ofrepTools.js";
 import type { OpenFeatureMCPServerInstance, ToolResult } from "./types.js";
 
 function handleToolError(error: unknown, toolName: string): ToolResult {
@@ -60,6 +61,7 @@ export function createServer(): McpServer {
   };
 
   registerInstallTools(serverAdapter);
+  registerOfrepTools(serverAdapter);
 
   return server;
 }

--- a/src/tools/ofrepTools.ts
+++ b/src/tools/ofrepTools.ts
@@ -1,0 +1,163 @@
+import { z } from "zod";
+import type { OpenFeatureMCPServerInstance, ToolResult } from "../types.js";
+
+const OfrepEvalArgsSchema = z.object({
+  baseUrl: z.string().url().optional(),
+  flag_key: z.string().optional(),
+  targetingKey: z.string().optional(),
+  context: z.record(z.any()).optional(),
+  apiKey: z.string().optional(),
+  bearerToken: z.string().optional(),
+  headers: z.record(z.string()).optional(),
+  ifNoneMatch: z.string().optional(),
+  timeoutMs: z.number().int().positive().optional(),
+});
+
+async function doFetchWithTimeout(
+  input: string,
+  init: RequestInit,
+  timeoutMs?: number
+): Promise<Response> {
+  if (!timeoutMs) return fetch(input, init);
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(input, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export function registerOfrepTools(
+  serverInstance: OpenFeatureMCPServerInstance
+): void {
+  serverInstance.registerToolWithErrorHandling(
+    "ofrep_flag_eval",
+    {
+      description:
+        "Evaluate flags via the OpenFeature Remote Evaluation Protocol (OFREP). If `flag_key` is provided evaluates a single flag, otherwise performs a bulk evaluation.",
+      inputSchema: OfrepEvalArgsSchema.shape,
+    },
+    async (args: unknown): Promise<ToolResult> => {
+      const parsed = OfrepEvalArgsSchema.safeParse(args);
+      if (!parsed.success) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Invalid input: ${parsed.error.message}`,
+            },
+          ],
+        };
+      }
+
+      const data = parsed.data;
+      const baseUrl =
+        data.baseUrl ?? process.env.OFREP_BASE_URL ?? "";
+      if (!baseUrl) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text:
+                "Missing base URL. Provide `baseUrl` or set OFREP_BASE_URL env var.",
+            },
+          ],
+        };
+      }
+
+      const bearerToken = data.bearerToken ?? process.env.OFREP_BEARER_TOKEN;
+      const apiKey = data.apiKey ?? process.env.OFREP_API_KEY;
+
+      const headers: Record<string, string> = {
+        "content-type": "application/json",
+        ...(data.headers ?? {}),
+      };
+      if (bearerToken) {
+        headers["authorization"] = `Bearer ${bearerToken}`;
+      } else if (apiKey) {
+        headers["x-api-key"] = apiKey;
+      }
+
+      const context: Record<string, unknown> = {
+        ...(data.context ?? {}),
+      };
+      if (data.targetingKey) {
+        context.targetingKey = data.targetingKey;
+      }
+
+      const isSingle = Boolean(data.flag_key);
+      const url = isSingle
+        ? `${baseUrl.replace(/\/$/, "")}/ofrep/v1/evaluate/flags/${encodeURIComponent(
+            data.flag_key as string
+          )}`
+        : `${baseUrl.replace(/\/$/, "")}/ofrep/v1/evaluate/flags`;
+
+      if (!isSingle && data.ifNoneMatch) {
+        headers["if-none-match"] = data.ifNoneMatch;
+      }
+
+      const body = JSON.stringify({ context });
+
+      try {
+        const res = await doFetchWithTimeout(
+          url,
+          { method: "POST", headers, body },
+          data.timeoutMs
+        );
+
+        const etag = res.headers.get("etag") ?? undefined;
+
+        if (res.status === 304) {
+          const result = {
+            status: res.status,
+            notModified: true,
+            etag,
+          };
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: JSON.stringify(result, null, 2),
+              },
+            ],
+          };
+        }
+
+        const text = await res.text();
+        let json: unknown;
+        try {
+          json = text ? JSON.parse(text) : {};
+        } catch {
+          json = { raw: text };
+        }
+
+        const result = {
+          status: res.status,
+          etag,
+          data: json,
+        };
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify(result, null, 2),
+            },
+          ],
+        };
+      } catch (e) {
+        const message = e instanceof Error ? e.message : String(e);
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `OFREP request failed: ${message}`,
+            },
+          ],
+        };
+      }
+    }
+  );
+}
+


### PR DESCRIPTION
Add `ofrep_flag_eval` tool for OpenFeature Remote Evaluation Protocol (OFREP) flag evaluations.

---
<a href="https://cursor.com/background-agent?bcId=bc-cd7d1332-ef19-44d9-af15-98edc846f293">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cd7d1332-ef19-44d9-af15-98edc846f293">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

